### PR TITLE
deaktivate old terminal and keyboard with setting

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,7 @@
 digipad = {}
-dofile(minetest.get_modpath("digipad").."/terminal.lua")  -- add terminal to mod
+if minetest.setting_getbool("digipad_terminal") then
+	dofile(minetest.get_modpath("digipad").."/terminal.lua")  -- add terminal to mod
+end
 -- ========================
 --Declare shared variables / functions
 -- ========================

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,2 @@
+#Enable the old terminal and keyboard.
+digipad_terminal (Enable Terminal) bool false


### PR DESCRIPTION
The interactive terminal and the digiline keyboard are very instable. This adds a setting to turn them on, which is normally off. These nodes make more problems than they bring features. If someone still likes them, he can turn the setting on, but those people are rare since there are other mods which do nearly the same but better. The most people only use this mod because of the digipad, I think, this change would make sense.